### PR TITLE
Simplify pickling logic by using __reduce__ instead of copy_reg

### DIFF
--- a/src/zope/securitypolicy/settings.py
+++ b/src/zope/securitypolicy/settings.py
@@ -49,22 +49,15 @@ class PermissionSetting(object):
     def getName(self):
         return self.__name
 
+    def __reduce__(self):
+        # register PermissionSettings to be symbolic constants by identity,
+        # even when pickled and unpickled.
+        return self.__name
+
     def __str__(self):
         return "PermissionSetting: %s" % self.__name
 
     __repr__ = __str__
-
-# register PermissionSettings to be symbolic constants by identity,
-# even when pickled and unpickled.
-try:
-    import copy_reg as copyreg
-except ImportError:
-    # Py3: Location change.
-    import copyreg
-copyreg.constructor(PermissionSetting)
-copyreg.pickle(PermissionSetting,
-               PermissionSetting.getName,
-               PermissionSetting)
 
 
 Allow = PermissionSetting(


### PR DESCRIPTION
The pickles produced this way are identical to the old ones.

One reason for this is that [mongopersist](https://pypi.python.org/pypi/mongopersist) currently doesn't implement the full pickle semantics and doesn't pay attention to the reduction function registered with the copy_reg module, but it can handle `__reduce__` just fine.
