### PR TITLE
Add support to grant multiple permissions with one ZCML statement.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,13 @@ Changes
 
 - Drop support for Python 2.6.
 
+- Add support to grant multiple permissions with one ZCML statement. Example::
+
+    <grant
+      role="my-role"
+      permissions="zope.foo
+                   zope.bar" />
+
 
 4.0.0 (2014-12-24)
 ------------------

--- a/src/zope/securitypolicy/metaconfigure.py
+++ b/src/zope/securitypolicy/metaconfigure.py
@@ -32,8 +32,10 @@ def grant(_context, principal=None, role=None, permission=None,
                   + (role is not None)
                   + (permission is not None)
                   + (permissions is not None))
+    permspecified = ((permission is not None)
+                     + (permissions is not None))
 
-    if nspecified != 2:
+    if nspecified != 2 or permspecified == 2:
         raise ConfigurationError(
             "Exactly two of the principal, role, and permission resp. "
             "permissions attributes must be specified")

--- a/src/zope/securitypolicy/metaconfigure.py
+++ b/src/zope/securitypolicy/metaconfigure.py
@@ -26,24 +26,29 @@ from zope.securitypolicy.principalrole import \
     principalRoleManager as principal_role_mgr
 
 
-def grant(_context, principal=None, role=None, permission=None):
+def grant(_context, principal=None, role=None, permission=None,
+          permissions=None):
     nspecified = ((principal is not None)
                   + (role is not None)
-                  + (permission is not None))
+                  + (permission is not None)
+                  + (permissions is not None))
 
     if nspecified != 2:
         raise ConfigurationError(
-            "Exactly two of the principal, role, and permission attributes "
-            "must be specified")
+            "Exactly two of the principal, role, and permission resp. "
+            "permissions attributes must be specified")
 
-    if principal:
-        if role:
-            _context.action(
-                discriminator=('grantRoleToPrincipal', role, principal),
-                callable=principal_role_mgr.assignRoleToPrincipal,
-                args=(role, principal),
-            )
-        else:
+    if permission:
+        permissions = [permission]
+
+    if principal and role:
+        _context.action(
+            discriminator=('grantRoleToPrincipal', role, principal),
+            callable=principal_role_mgr.assignRoleToPrincipal,
+            args=(role, principal),
+        )
+    elif principal and permissions:
+        for permission in permissions:
             _context.action(
                 discriminator=('grantPermissionToPrincipal',
                                permission,
@@ -51,12 +56,13 @@ def grant(_context, principal=None, role=None, permission=None):
                 callable=principal_perm_mgr.grantPermissionToPrincipal,
                 args=(permission, principal),
             )
-    else:
-        _context.action(
-            discriminator=('grantPermissionToRole', permission, role),
-            callable=role_perm_mgr.grantPermissionToRole,
-            args=(permission, role),
-        )
+    elif role and permissions:
+        for permission in permissions:
+            _context.action(
+                discriminator=('grantPermissionToRole', permission, role),
+                callable=role_perm_mgr.grantPermissionToRole,
+                args=(permission, role),
+            )
 
 
 def grantAll(_context, principal=None, role=None):

--- a/src/zope/securitypolicy/metadirectives.py
+++ b/src/zope/securitypolicy/metadirectives.py
@@ -13,6 +13,7 @@
 ##############################################################################
 """Grant Directive Schema
 """
+from zope.configuration.fields import Tokens
 from zope.interface import Interface
 from zope.schema import Id
 from zope.security.zcml import Permission, IPermissionDirective
@@ -38,6 +39,12 @@ class IGrantDirective(IGrantAllDirective):
     permission = Permission(
         title=u"Permission",
         description=u"Specifies the Permission to be mapped.",
+        required=False)
+
+    permissions = Tokens(
+        title=u"Permissions",
+        description=u"Specifies a list of permissions to be mapped.",
+        value_type=Permission(),
         required=False)
 
 

--- a/src/zope/securitypolicy/metadirectives.py
+++ b/src/zope/securitypolicy/metadirectives.py
@@ -43,7 +43,9 @@ class IGrantDirective(IGrantAllDirective):
 
     permissions = Tokens(
         title=u"Permissions",
-        description=u"Specifies a list of permissions to be mapped.",
+        description=(
+            u"Specifies a whitespace-separated list of permissions to be "
+            u"mapped."),
         value_type=Permission(),
         required=False)
 

--- a/src/zope/securitypolicy/tests/mapping.zcml
+++ b/src/zope/securitypolicy/tests/mapping.zcml
@@ -8,8 +8,20 @@
       />
 
   <grant
+      permissions="zope.Qwer
+                   zope.Qux"
+      role="zope.Fox"
+      />
+
+  <grant
       permission="zope.Foo"
       principal="zope.Blah"
+      />
+
+  <grant
+      permissions="zope.Qwer
+                   zope.Qux"
+      principal="zope.One"
       />
 
   <grant

--- a/src/zope/securitypolicy/tests/permission_and_permissions.zcml
+++ b/src/zope/securitypolicy/tests/permission_and_permissions.zcml
@@ -1,0 +1,11 @@
+<configure xmlns="http://namespaces.zope.org/zope">
+
+  <include package="zope.securitypolicy" file="meta.zcml"/>
+
+  <grant
+      permission="zope.Foo"
+      permissions="zope.Qwer
+                   zope.Qux"
+      />
+
+</configure>

--- a/src/zope/securitypolicy/tests/test_securitydirectives.py
+++ b/src/zope/securitypolicy/tests/test_securitydirectives.py
@@ -72,8 +72,14 @@ class TestSecurityMapping(TestBase, unittest.TestCase):
         super(TestSecurityMapping, self).setUp()
         zope.component.provideUtility(Permission('zope.Foo', ''),
                                       IPermission, 'zope.Foo')
+        zope.component.provideUtility(Permission('zope.Qwer', ''),
+                                      IPermission, 'zope.Qwer')
+        zope.component.provideUtility(Permission('zope.Qux', ''),
+                                      IPermission, 'zope.Qux')
         defineRole("zope.Bar", '', '')
+        defineRole("zope.Fox", '', '')
         principalRegistry.definePrincipal("zope.Blah", '', '')
+        principalRegistry.definePrincipal("zope.One", '', '')
         self.context = xmlconfig.file(
             "mapping.zcml", zope.securitypolicy.tests)
 
@@ -87,6 +93,21 @@ class TestSecurityMapping(TestBase, unittest.TestCase):
         self.assertEqual(len(perms), 1)
         self.assertTrue(("zope.Foo", Allow) in perms)
 
+    def test_PermRoleMap_multiple(self):
+        quer_roles = role_perm_mgr.getRolesForPermission("zope.Qwer")
+        qux_roles = role_perm_mgr.getRolesForPermission("zope.Qux")
+        perms = role_perm_mgr.getPermissionsForRole("zope.Fox")
+
+        self.assertEqual(len(quer_roles), 1)
+        self.assertTrue(("zope.Fox", Allow) in quer_roles)
+
+        self.assertEqual(len(qux_roles), 1)
+        self.assertTrue(("zope.Fox", Allow) in qux_roles)
+
+        self.assertEqual(len(perms), 2)
+        self.assertTrue(("zope.Qwer", Allow) in perms)
+        self.assertTrue(("zope.Qux", Allow) in perms)
+
     def test_PermPrincipalMap(self):
         principals = principal_perm_mgr.getPrincipalsForPermission("zope.Foo")
         perms = principal_perm_mgr.getPermissionsForPrincipal("zope.Blah")
@@ -96,6 +117,23 @@ class TestSecurityMapping(TestBase, unittest.TestCase):
 
         self.assertEqual(len(perms), 1)
         self.assertTrue(("zope.Foo", Allow) in perms)
+
+    def test_PermPrincipalMap_multiple(self):
+        quer_principals = principal_perm_mgr.getPrincipalsForPermission(
+            "zope.Qwer")
+        qux_principals = principal_perm_mgr.getPrincipalsForPermission(
+            "zope.Qux")
+        perms = principal_perm_mgr.getPermissionsForPrincipal("zope.One")
+
+        self.assertEqual(len(quer_principals), 1)
+        self.assertTrue(("zope.One", Allow) in quer_principals)
+
+        self.assertEqual(len(qux_principals), 1)
+        self.assertTrue(("zope.One", Allow) in qux_principals)
+
+        self.assertEqual(len(perms), 2)
+        self.assertTrue(("zope.Qwer", Allow) in perms)
+        self.assertTrue(("zope.Qux", Allow) in perms)
 
     def test_RolePrincipalMap(self):
         principals = principal_role_mgr.getPrincipalsForRole("zope.Bar")

--- a/src/zope/securitypolicy/tests/test_securitydirectives.py
+++ b/src/zope/securitypolicy/tests/test_securitydirectives.py
@@ -18,6 +18,7 @@ import unittest
 import zope.component
 from zope.configuration import xmlconfig
 from zope.configuration.config import ConfigurationConflictError
+from zope.configuration.exceptions import ConfigurationError
 from zope.security.interfaces import IPermission
 from zope.security.permission import Permission
 
@@ -107,6 +108,11 @@ class TestSecurityMapping(TestBase, unittest.TestCase):
         self.assertEqual(len(perms), 2)
         self.assertTrue(("zope.Qwer", Allow) in perms)
         self.assertTrue(("zope.Qux", Allow) in perms)
+
+    def test_PermRoleMap_does_not_allow_permission_and_permissions(self):
+        with self.assertRaises(ConfigurationError):
+            xmlconfig.file(
+                "permission_and_permissions.zcml", zope.securitypolicy.tests)
 
     def test_PermPrincipalMap(self):
         principals = principal_perm_mgr.getPrincipalsForPermission("zope.Foo")


### PR DESCRIPTION
This is #5 without the PEP-8 fixes.