### PR TITLE
Setting __bool__ to __nonzero__ behaves differently in Python 3

### DIFF
--- a/src/zope/securitypolicy/securitymap.py
+++ b/src/zope/securitypolicy/securitymap.py
@@ -30,7 +30,8 @@ class SecurityMap(object):
     def __nonzero__(self):
         return bool(self._byrow)
 
-    __bool__ = __nonzero__
+    def __bool__(self):
+        return self.__nonzero__()
 
     def addCell(self, rowentry, colentry, value):
         # setdefault may get expensive if an empty mapping is

--- a/src/zope/securitypolicy/tests/test_securitymap.py
+++ b/src/zope/securitypolicy/tests/test_securitymap.py
@@ -208,3 +208,17 @@ class TestAnnotationSecurityMap(unittest.TestCase):
         self.assertIn(ASM.key, context.annotations)
         psm = context.annotations[ASM.key]
         self.assertIs(psm, sec_map.map)
+
+
+class TestSecurityMapInheritance(unittest.TestCase):
+
+    def test_inheritance(self):
+
+        from zope.securitypolicy.securitymap import SecurityMap
+        class CustomSecurityMap(SecurityMap):
+
+            def __nonzero__(self):
+                return True
+
+        security_map = CustomSecurityMap()
+        self.assertTrue(security_map)


### PR DESCRIPTION
This change restores the Python 2 behavior.